### PR TITLE
Add community feeds and posts

### DIFF
--- a/lib/src/models/authorperm.dart
+++ b/lib/src/models/authorperm.dart
@@ -20,6 +20,7 @@ class Authorperm extends Equatable {
 
   static List<Authorperm> deserializeList(List posts) =>
       posts.map((dynamic s) => Authorperm.parse(s as String)).toList();
+
   static List<String> serializeList(List<Authorperm> posts) =>
       posts.map((p) => p.toString()).toList();
 

--- a/lib/src/models/authorperm.dart
+++ b/lib/src/models/authorperm.dart
@@ -18,6 +18,11 @@ class Authorperm extends Equatable {
     );
   }
 
+  static List<Authorperm> deserializeList(List posts) =>
+      posts.map((dynamic s) => Authorperm.parse(s as String)).toList();
+  static List<String> serializeList(List<Authorperm> posts) =>
+      posts.map((p) => p.toString()).toList();
+
   final String author;
   final String permlink;
 

--- a/lib/src/models/community_feed.dart
+++ b/lib/src/models/community_feed.dart
@@ -6,7 +6,11 @@ part 'community_feed.g.dart';
 
 @JsonSerializable(explicitToJson: true)
 class CommunityFeed extends Equatable {
-  const CommunityFeed({required this.posts, required this.lastOpIndex});
+  const CommunityFeed({
+    required this.posts,
+    required this.lastOpIndices,
+    required this.oldestQuery,
+  });
 
   factory CommunityFeed.fromJson(Map<String, dynamic> json) {
     return _$CommunityFeedFromJson(json);
@@ -17,7 +21,8 @@ class CommunityFeed extends Equatable {
     toJson: Authorperm.serializeList,
   )
   final List<Authorperm> posts;
-  final Map<String, int> lastOpIndex;
+  final Map<String, int> lastOpIndices;
+  final DateTime oldestQuery;
 
   int get length => posts.length;
 
@@ -29,18 +34,20 @@ class CommunityFeed extends Equatable {
 
   CommunityFeed copyWith({
     List<Authorperm>? posts,
-    Map<String, int>? lastOpIndex,
+    Map<String, int>? lastOpIndices,
+    DateTime? oldestQuery,
   }) {
     return CommunityFeed(
       posts: posts ?? this.posts,
-      lastOpIndex: lastOpIndex ?? this.lastOpIndex,
+      lastOpIndices: lastOpIndices ?? this.lastOpIndices,
+      oldestQuery: oldestQuery ?? this.oldestQuery,
     );
   }
 
   Map<String, dynamic> toJson() => _$CommunityFeedToJson(this);
 
   @override
-  List<Object?> get props => [posts, lastOpIndex];
+  List<Object?> get props => [posts, lastOpIndices, oldestQuery];
 
   @override
   bool get stringify => true;

--- a/lib/src/models/community_feed.dart
+++ b/lib/src/models/community_feed.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:lightning_api/src/models/models.dart';
+
+part 'community_feed.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class CommunityFeed extends Equatable {
+  const CommunityFeed({required this.posts, required this.lastOpIndex});
+
+  factory CommunityFeed.fromJson(Map<String, dynamic> json) {
+    return _$CommunityFeedFromJson(json);
+  }
+
+  @JsonKey(
+    fromJson: Authorperm.deserializeList,
+    toJson: Authorperm.serializeList,
+  )
+  final List<Authorperm> posts;
+  final Map<String, int> lastOpIndex;
+
+  int get length => posts.length;
+
+  bool get isEmpty => posts.isEmpty;
+
+  bool get isNotEmpty => posts.isNotEmpty;
+
+  Authorperm operator [](int index) => posts[index];
+
+  CommunityFeed copyWith({
+    List<Authorperm>? posts,
+    Map<String, int>? lastOpIndex,
+  }) {
+    return CommunityFeed(
+      posts: posts ?? this.posts,
+      lastOpIndex: lastOpIndex ?? this.lastOpIndex,
+    );
+  }
+
+  Map<String, dynamic> toJson() => _$CommunityFeedToJson(this);
+
+  @override
+  List<Object?> get props => [posts, lastOpIndex];
+
+  @override
+  bool get stringify => true;
+}

--- a/lib/src/models/community_feed.dart
+++ b/lib/src/models/community_feed.dart
@@ -7,7 +7,7 @@ part 'community_feed.g.dart';
 @JsonSerializable(explicitToJson: true)
 class CommunityFeed extends Equatable {
   const CommunityFeed({
-    required this.posts,
+    required this.postIds,
     required this.lastOpIndices,
     required this.oldestQuery,
   });
@@ -20,25 +20,25 @@ class CommunityFeed extends Equatable {
     fromJson: Authorperm.deserializeList,
     toJson: Authorperm.serializeList,
   )
-  final List<Authorperm> posts;
+  final List<Authorperm> postIds;
   final Map<String, int> lastOpIndices;
   final DateTime oldestQuery;
 
-  int get length => posts.length;
+  int get length => postIds.length;
 
-  bool get isEmpty => posts.isEmpty;
+  bool get isEmpty => postIds.isEmpty;
 
-  bool get isNotEmpty => posts.isNotEmpty;
+  bool get isNotEmpty => postIds.isNotEmpty;
 
-  Authorperm operator [](int index) => posts[index];
+  Authorperm operator [](int index) => postIds[index];
 
   CommunityFeed copyWith({
-    List<Authorperm>? posts,
+    List<Authorperm>? postIds,
     Map<String, int>? lastOpIndices,
     DateTime? oldestQuery,
   }) {
     return CommunityFeed(
-      posts: posts ?? this.posts,
+      postIds: postIds ?? this.postIds,
       lastOpIndices: lastOpIndices ?? this.lastOpIndices,
       oldestQuery: oldestQuery ?? this.oldestQuery,
     );
@@ -47,7 +47,7 @@ class CommunityFeed extends Equatable {
   Map<String, dynamic> toJson() => _$CommunityFeedToJson(this);
 
   @override
-  List<Object?> get props => [posts, lastOpIndices, oldestQuery];
+  List<Object?> get props => [postIds, lastOpIndices, oldestQuery];
 
   @override
   bool get stringify => true;

--- a/lib/src/models/community_feed.g.dart
+++ b/lib/src/models/community_feed.g.dart
@@ -9,11 +9,13 @@ part of 'community_feed.dart';
 CommunityFeed _$CommunityFeedFromJson(Map<String, dynamic> json) =>
     CommunityFeed(
       posts: Authorperm.deserializeList(json['posts'] as List),
-      lastOpIndex: Map<String, int>.from(json['lastOpIndex'] as Map),
+      lastOpIndices: Map<String, int>.from(json['lastOpIndices'] as Map),
+      oldestQuery: DateTime.parse(json['oldestQuery'] as String),
     );
 
 Map<String, dynamic> _$CommunityFeedToJson(CommunityFeed instance) =>
     <String, dynamic>{
       'posts': Authorperm.serializeList(instance.posts),
-      'lastOpIndex': instance.lastOpIndex,
+      'lastOpIndices': instance.lastOpIndices,
+      'oldestQuery': instance.oldestQuery.toIso8601String(),
     };

--- a/lib/src/models/community_feed.g.dart
+++ b/lib/src/models/community_feed.g.dart
@@ -8,14 +8,14 @@ part of 'community_feed.dart';
 
 CommunityFeed _$CommunityFeedFromJson(Map<String, dynamic> json) =>
     CommunityFeed(
-      posts: Authorperm.deserializeList(json['posts'] as List),
+      postIds: Authorperm.deserializeList(json['postIds'] as List),
       lastOpIndices: Map<String, int>.from(json['lastOpIndices'] as Map),
       oldestQuery: DateTime.parse(json['oldestQuery'] as String),
     );
 
 Map<String, dynamic> _$CommunityFeedToJson(CommunityFeed instance) =>
     <String, dynamic>{
-      'posts': Authorperm.serializeList(instance.posts),
+      'postIds': Authorperm.serializeList(instance.postIds),
       'lastOpIndices': instance.lastOpIndices,
       'oldestQuery': instance.oldestQuery.toIso8601String(),
     };

--- a/lib/src/models/community_feed.g.dart
+++ b/lib/src/models/community_feed.g.dart
@@ -1,19 +1,19 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'feed.dart';
+part of 'community_feed.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-Feed _$FeedFromJson(Map<String, dynamic> json) => Feed(
-      tag: json['tag'] as String,
-      sort: json['sort'] as String,
+CommunityFeed _$CommunityFeedFromJson(Map<String, dynamic> json) =>
+    CommunityFeed(
       posts: Authorperm.deserializeList(json['posts'] as List),
+      lastOpIndex: Map<String, int>.from(json['lastOpIndex'] as Map),
     );
 
-Map<String, dynamic> _$FeedToJson(Feed instance) => <String, dynamic>{
-      'tag': instance.tag,
-      'sort': instance.sort,
+Map<String, dynamic> _$CommunityFeedToJson(CommunityFeed instance) =>
+    <String, dynamic>{
       'posts': Authorperm.serializeList(instance.posts),
+      'lastOpIndex': instance.lastOpIndex,
     };

--- a/lib/src/models/community_posts.dart
+++ b/lib/src/models/community_posts.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:lightning_api/src/models/models.dart';
+
+part 'community_posts.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class CommunityPosts extends Equatable {
+  const CommunityPosts({required this.feed, required this.posts});
+
+  factory CommunityPosts.fromJson(Map<String, dynamic> json) {
+    return _$CommunityPostsFromJson(json);
+  }
+
+  final CommunityFeed feed;
+  final List<Post?> posts;
+
+  int get length => posts.length;
+
+  bool get isEmpty => posts.isEmpty;
+
+  bool get isNotEmpty => posts.isNotEmpty;
+
+  Post? operator [](int index) => posts[index];
+
+  CommunityPosts copyWith({
+    CommunityFeed? feed,
+    List<Post?>? posts,
+  }) {
+    return CommunityPosts(
+      feed: feed ?? this.feed,
+      posts: posts ?? this.posts,
+    );
+  }
+
+  Map<String, dynamic> toJson() => _$CommunityPostsToJson(this);
+
+  // Using just the feed to shallow compare
+  @override
+  List<Object?> get props => [feed];
+
+  @override
+  bool get stringify => true;
+}

--- a/lib/src/models/community_posts.g.dart
+++ b/lib/src/models/community_posts.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'community_posts.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CommunityPosts _$CommunityPostsFromJson(Map<String, dynamic> json) =>
+    CommunityPosts(
+      feed: CommunityFeed.fromJson(json['feed'] as Map<String, dynamic>),
+      posts: (json['posts'] as List<dynamic>)
+          .map((e) =>
+              e == null ? null : Post.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$CommunityPostsToJson(CommunityPosts instance) =>
+    <String, dynamic>{
+      'feed': instance.feed.toJson(),
+      'posts': instance.posts.map((e) => e?.toJson()).toList(),
+    };

--- a/lib/src/models/feed.dart
+++ b/lib/src/models/feed.dart
@@ -15,14 +15,11 @@ class Feed extends Equatable {
   final String tag;
   final String sort;
 
-  @JsonKey(fromJson: _toAuthorpermList, toJson: _fromAuthorpermList)
+  @JsonKey(
+      fromJson: Authorperm.deserializeList,
+      toJson: Authorperm.serializeList,
+  )
   final List<Authorperm> posts;
-
-  static List<Authorperm> _toAuthorpermList(List posts) =>
-      posts.map((dynamic s) => Authorperm.parse(s as String)).toList();
-
-  static List<String> _fromAuthorpermList(List<Authorperm> posts) =>
-      posts.map((p) => p.toString()).toList();
 
   int get length => posts.length;
 

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -11,6 +11,7 @@ export 'account.dart';
 export 'authorperm.dart';
 export 'comment.dart';
 export 'comments.dart';
+export 'community_feed.dart';
 export 'content.dart';
 export 'feed.dart';
 export 'manabar.dart';

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -12,6 +12,7 @@ export 'authorperm.dart';
 export 'comment.dart';
 export 'comments.dart';
 export 'community_feed.dart';
+export 'community_posts.dart';
 export 'content.dart';
 export 'feed.dart';
 export 'manabar.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lightning_api
 description: Provices a Stream interface to the LeoFinance Lightning HTTP API.
-version: 0.3.4
+version: 0.4.0
 repository: https://github.com/LeoFinance/lightning-api
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.3
-  hive_api: ^0.2.1
+  hive-api: ^0.3.0
   http: ^0.13.3
   intl: ^0.17.0
   json_annotation: ^4.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.3
-  hive-api: ^0.3.0
+  hive_api: ^0.3.0
   http: ^0.13.3
   intl: ^0.17.0
   json_annotation: ^4.5.0


### PR DESCRIPTION
This creates models for new API request. These are both used for storage and requests, using or ignoring these metadata is up to the sender of request. To DRY, I did extract static authorperm code into authorperm itself.